### PR TITLE
chore (ci): add Node.js 17 and run CI linting only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,38 +3,50 @@ name: GitHub CI
 on: [push, pull_request]
 
 jobs:
-  test:
-
+  linter:
     runs-on: ubuntu-latest
-    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install
+        run: npm install
+
+      - name: Lint code
+        run: npm run lint
+
+  test:
+    needs: linter
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    
+        node-version: [10, 12, 14, 16, 17]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     steps:
     - uses: actions/checkout@v2
       
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Install
-      run: |
-        npm install
+      run: npm install
 
     - name: Run tests & generate coverage
-      run: |
-        npm run lint
-        npm run test:ci
-        
+      run: npm run test:ci
+
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel: true
-        
 
   coverage:
     needs: test

--- a/package.json
+++ b/package.json
@@ -4,17 +4,14 @@
   "description": "Nodemailer instance initialization and encapsulation in fastify framework",
   "main": "plugin.js",
   "scripts": {
-    "coverage": "npm run unit -- --cov --coverage-report=html",
-    "coveralls": "npm run unit -- --cov",
     "lint": "standard --verbose | snazzy",
     "lint:fix": "standard --fix --verbose | snazzy",
     "test": "npm run lint && npm run unit",
-    "test:ci": "npm run lint && npm run unit -- --cov --coverage-report=lcov --no-browser && npm run test:typescript",
-    "test:report": "npm run lint && npm run unit:report",
+    "test:ci": "npm run unit -- --cov --coverage-report=lcov --no-browser && npm run test:typescript",
     "test:typescript": "tsd",
     "unit": "tap -J test/plugin.test.js",
-    "unit:report": "tap -J test/plugin.test.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",
-    "unit:verbose": "tap -J test/plugin.test.js -Rspec"
+    "unit:report": "npm run unit -- --cov --coverage-report=html",
+    "unit:verbose": "npm run unit -- -Rspec"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "devDependencies": {
     "@types/nodemailer": "^6.4.4",
     "coveralls": "^3.1.1",
-    "fastify": "^3.24.0",
-    "nodemailer": "^6.7.1",
+    "fastify": "^3.27.0",
+    "nodemailer": "^6.7.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.4",
-    "tap": "^15.1.2",
-    "tsd": "^0.19.0",
-    "typescript": "^4.5.2"
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1",
+    "typescript": "^4.5.5"
   },
   "peerDependencies": {
     "nodemailer": ">=6.0.0"


### PR DESCRIPTION
- add Node.js 17 to the CI matrix
- update package dependencies
- run CI linting only once